### PR TITLE
Release 3356 | Raise error when error 413 is likely to happen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [ "2.7", "3.0", "3.1.2" ]
+        ruby-version: [ "3.1", "3.2", "3.3" ]
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [ "3.1", "3.2", "3.3" ]
+        ruby-version: [ "3.3" ]
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [ "3.3" ]
+        ruby-version: [ "3.1", "3.2", "3.3" ]
     steps:
     - uses: actions/checkout@v2
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  TargetRubyVersion: 3.3
+
 Metrics/BlockLength:
   Exclude:
     - msteams_hermes.gemspec

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,7 @@
-AllCops:
-  TargetRubyVersion: 2.7
-
 Metrics/BlockLength:
   Exclude:
-    - 'spec/**/*'
+    - msteams_hermes.gemspec
+    - spec/**/*
 
 Style/StringLiterals:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.3
+  TargetRubyVersion: 3.1
 
 Metrics/BlockLength:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+## [1.1.1] - 2023-01-24
+- Prevent causing 413 response from microsoft teams webhook
+
 ## [1.1.0] - 2023-01-24
 - Add support for @mentions
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in msteams_hermes.gemspec
 gemspec
-
-gem "rake"
-gem "rspec"
-gem "rubocop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,48 +1,54 @@
 PATH
   remote: .
   specs:
-    msteams_hermes (1.1.0)
+    msteams_hermes (1.1.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    diff-lcs (1.5.0)
-    json (2.6.2)
-    parallel (1.22.1)
-    parser (3.1.2.1)
+    diff-lcs (1.5.1)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
+    parallel (1.24.0)
+    parser (3.3.1.0)
       ast (~> 2.4.1)
+      racc
+    racc (1.8.0)
     rainbow (3.1.1)
-    rake (13.0.6)
-    regexp_parser (2.5.0)
-    rexml (3.2.5)
-    rspec (3.11.0)
-      rspec-core (~> 3.11.0)
-      rspec-expectations (~> 3.11.0)
-      rspec-mocks (~> 3.11.0)
-    rspec-core (3.11.0)
-      rspec-support (~> 3.11.0)
-    rspec-expectations (3.11.0)
+    rake (13.2.1)
+    regexp_parser (2.9.2)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.11.0)
-    rspec-mocks (3.11.1)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.11.0)
-    rspec-support (3.11.0)
-    rubocop (1.36.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
+    rubocop (1.63.5)
       json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.1.2.1)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.20.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.21.0)
-      parser (>= 3.1.1.0)
-    ruby-progressbar (1.11.0)
-    unicode-display_width (2.2.0)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
+    ruby-progressbar (1.13.0)
+    strscan (3.1.0)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
   ruby
@@ -56,4 +62,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.2.15
+   2.5.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,14 +6,31 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    bigdecimal (3.1.8)
+    byebug (11.1.3)
+    coderay (1.1.3)
+    crack (1.0.0)
+      bigdecimal
+      rexml
     diff-lcs (1.5.1)
+    hashdiff (1.1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
+    method_source (1.1.0)
     parallel (1.24.0)
     parser (3.3.1.0)
       ast (~> 2.4.1)
       racc
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+    public_suffix (5.0.5)
     racc (1.8.0)
     rainbow (3.1.1)
     rake (13.2.1)
@@ -49,17 +66,21 @@ GEM
     ruby-progressbar (1.13.0)
     strscan (3.1.0)
     unicode-display_width (2.5.0)
+    webmock (3.23.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   ruby
-  x86_64-darwin-20
-  x86_64-darwin-21
 
 DEPENDENCIES
   msteams_hermes!
+  pry-byebug
   rake
   rspec
   rubocop
+  webmock (~> 3.23)
 
 BUNDLED WITH
    2.5.10

--- a/complex_example.rb
+++ b/complex_example.rb
@@ -72,4 +72,4 @@ content = MsTeamsHermes::Components::AdaptiveCard.new(
   ]
 )
 
-MsTeamsHermes::Message.new(webhook_url: YOUR_WEBHOOK_URL, content: content).deliver
+MsTeamsHermes::Message.new(webhook_url: YOUR_WEBHOOK_URL, content:).deliver

--- a/lib/msteams_hermes/actions/open_url.rb
+++ b/lib/msteams_hermes/actions/open_url.rb
@@ -20,9 +20,9 @@ module MsTeamsHermes
       def to_hash
         {
           type: "Action.OpenUrl",
-          url: url,
-          title: title,
-          tooltip: tooltip
+          url:,
+          title:,
+          tooltip:
         }
       end
     end

--- a/lib/msteams_hermes/components/adaptive_card.rb
+++ b/lib/msteams_hermes/components/adaptive_card.rb
@@ -38,7 +38,7 @@ module MsTeamsHermes
           actions: actions&.map(&:to_hash),
           msteams: {
             entities: entities.map(&:to_hash),
-            width: width
+            width:
           }
         }
       end

--- a/lib/msteams_hermes/components/column.rb
+++ b/lib/msteams_hermes/components/column.rb
@@ -25,7 +25,7 @@ module MsTeamsHermes
       def to_hash
         {
           type: "Column",
-          width: width,
+          width:,
           items: items.map(&:to_hash)
         }
       end

--- a/lib/msteams_hermes/components/container.rb
+++ b/lib/msteams_hermes/components/container.rb
@@ -27,7 +27,7 @@ module MsTeamsHermes
       def to_hash
         {
           type: "Container",
-          style: style,
+          style:,
           selectAction: select_action&.to_hash,
           items: items.map(&:to_hash)
         }

--- a/lib/msteams_hermes/components/fact_set.rb
+++ b/lib/msteams_hermes/components/fact_set.rb
@@ -23,7 +23,7 @@ module MsTeamsHermes
       def to_hash
         {
           type: "FactSet",
-          facts: facts
+          facts:
         }
       end
 

--- a/lib/msteams_hermes/components/text_block.rb
+++ b/lib/msteams_hermes/components/text_block.rb
@@ -37,13 +37,13 @@ module MsTeamsHermes
       def to_hash
         {
           type: "TextBlock",
-          text: text,
-          color: color,
-          size: size,
-          font_type: font_type,
-          weight: weight,
-          wrap: wrap,
-          is_subtle: is_subtle
+          text:,
+          color:,
+          size:,
+          font_type:,
+          weight:,
+          wrap:,
+          is_subtle:
         }
       end
     end

--- a/lib/msteams_hermes/message.rb
+++ b/lib/msteams_hermes/message.rb
@@ -62,6 +62,8 @@ module MsTeamsHermes
 
         response = http.request(req)
 
+        # For details see:
+        # https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL%2Ctext1#send-messages-using-curl-and-powershell
         if response.body != "1"
           raise MessageBodyTooLargeError, body_json.bytesize if response.body.include? MSTEAMS_MESSAGE_413_ERROR_TOKEN
 

--- a/lib/msteams_hermes/message.rb
+++ b/lib/msteams_hermes/message.rb
@@ -30,7 +30,7 @@ module MsTeamsHermes
     end
 
     MSTEAMS_MESSAGE_SIZE_LIMIT = 21_000
-    MSTEAMS_MESSAGE_413_ERROR_TOKEN = 'returned HTTP error 413'
+    MSTEAMS_MESSAGE_413_ERROR_TOKEN = "returned HTTP error 413"
 
     attr_reader :webhook_url, :content
 
@@ -57,8 +57,9 @@ module MsTeamsHermes
 
         response = http.request(req)
 
-        if response.body != '1'
+        if response.body != "1"
           raise MessageBodyTooLargeError, body_json.bytesize if response.body.include? MSTEAMS_MESSAGE_413_ERROR_TOKEN
+
           raise UnknownError, response.body
         end
 

--- a/lib/msteams_hermes/message.rb
+++ b/lib/msteams_hermes/message.rb
@@ -9,9 +9,12 @@ module MsTeamsHermes
   # https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL#send-adaptive-cards-using-an-incoming-webhook
   ##
   class Message
+    ##
+    # Raise when the message is larger than the latest known maximum size of microsoft teams messages
     class MessageBodyLikelyTooLargeError < StandardError
       def initialize(current_size)
-        super("Given our latest information microsoft teams has a size limitation of about #{MSTEAMS_MESSAGE_SIZE_LIMIT} bytes." \
+        super("Given our latest information" \
+              " microsoft teams has a size limitation of about #{MSTEAMS_MESSAGE_SIZE_LIMIT} bytes." \
               "\nYour message results in a size of about #{current_size} bytes which would result in an error")
       end
     end
@@ -39,9 +42,8 @@ module MsTeamsHermes
       Net::HTTP.start(uri.host, uri.port, use_ssl: true, verify_mode: OpenSSL::SSL::VERIFY_NONE) do |http|
         req = Net::HTTP::Post.new(uri)
         req.body = body_json
-        if body_json.bytesize > MSTEAMS_MESSAGE_SIZE_LIMIT
-          raise MessageBodyLikelyTooLargeError.new(body_json.bytesize)
-        end
+        raise MessageBodyLikelyTooLargeError, body_json.bytesize if body_json.bytesize > MSTEAMS_MESSAGE_SIZE_LIMIT
+
         req["Content-Type"] = "application/json"
         http.request(req)
       end

--- a/lib/msteams_hermes/message.rb
+++ b/lib/msteams_hermes/message.rb
@@ -42,6 +42,8 @@ module MsTeamsHermes
       raise "Message `content` must be an AdaptiveCard" unless @content.is_a? Components::AdaptiveCard
     end
 
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength
     ##
     # Sends a HTTP request to the webhook URL specified via
     # either environment variable or when initializing the class
@@ -66,6 +68,8 @@ module MsTeamsHermes
         response
       end
     end
+    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength
 
     ##
     # Formats the JSON object to be set on the HTTP request

--- a/lib/msteams_hermes/message.rb
+++ b/lib/msteams_hermes/message.rb
@@ -29,6 +29,9 @@ module MsTeamsHermes
       end
     end
 
+    # Docu says: 'The message size limit is 28 KB',
+    # but testing aligned with 21KB.
+    # See: https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook
     MSTEAMS_MESSAGE_SIZE_LIMIT = 21_000
     MSTEAMS_MESSAGE_413_ERROR_TOKEN = "returned HTTP error 413"
 

--- a/lib/msteams_hermes/version.rb
+++ b/lib/msteams_hermes/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MsTeamsHermes
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end

--- a/msteams_hermes.gemspec
+++ b/msteams_hermes.gemspec
@@ -16,11 +16,12 @@ Gem::Specification.new do |spec|
                        "Microsoft's adaptive cards."
   spec.homepage      = "https://github.com/xing/msteams_hermes"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/xing/msteams_hermes"
   spec.metadata["changelog_uri"] = "https://github.com/xing/msteams_hermes/CHANGELOG.md"
+
+   spec.required_ruby_version = Gem::Requirement.new(">= 3.0")
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -34,6 +35,9 @@ Gem::Specification.new do |spec|
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
 
-  # For more information and examples about making a new gem, checkout our
-  # guide at: https://bundler.io/guides/creating_gem.html
+  spec.add_development_dependency "pry-byebug"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "webmock", "~> 3.23"
 end

--- a/msteams_hermes.gemspec
+++ b/msteams_hermes.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/xing/msteams_hermes"
   spec.metadata["changelog_uri"] = "https://github.com/xing/msteams_hermes/CHANGELOG.md"
 
-   spec.required_ruby_version = Gem::Requirement.new(">= 3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.3")
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/msteams_hermes.gemspec
+++ b/msteams_hermes.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/xing/msteams_hermes"
   spec.metadata["changelog_uri"] = "https://github.com/xing/msteams_hermes/CHANGELOG.md"
 
-  spec.required_ruby_version = Gem::Requirement.new(">= 3.3")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.1")
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/spec/msteams_hermes/actions/open_url_spec.rb
+++ b/spec/msteams_hermes/actions/open_url_spec.rb
@@ -4,14 +4,14 @@ require "msteams_hermes/actions/open_url"
 
 RSpec.describe MsTeamsHermes::Actions::OpenUrl do
   describe "#to_hash" do
-    subject(:action) { MsTeamsHermes::Actions::OpenUrl.new(url: url, title: title, tooltip: tooltip) }
+    subject(:action) { MsTeamsHermes::Actions::OpenUrl.new(url:, title:, tooltip:) }
 
     let(:url) { "https://foo" }
     let(:title) { "any title" }
     let(:tooltip) { "any tooltip" }
 
     it "renders the hash object" do
-      expect(action.to_hash).to eq({ type: "Action.OpenUrl", url: url, title: title, tooltip: tooltip })
+      expect(action.to_hash).to eq({ type: "Action.OpenUrl", url:, title:, tooltip: })
     end
   end
 end

--- a/spec/msteams_hermes/components/adaptive_card_spec.rb
+++ b/spec/msteams_hermes/components/adaptive_card_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe MsTeamsHermes::Components::AdaptiveCard do
 
   describe "#to_hash" do
     subject(:component) do
-      MsTeamsHermes::Components::AdaptiveCard.new(body: [fact_set], actions: [action], width: width)
+      MsTeamsHermes::Components::AdaptiveCard.new(body: [fact_set], actions: [action], width:)
     end
 
     let(:fact_set) { MsTeamsHermes::Components::FactSet.new(facts: [fact]) }

--- a/spec/msteams_hermes/components/column_spec.rb
+++ b/spec/msteams_hermes/components/column_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe MsTeamsHermes::Components::Column do
   end
 
   describe "#to_hash" do
-    subject(:component) { MsTeamsHermes::Components::Column.new(items: [fact_set], width: width) }
+    subject(:component) { MsTeamsHermes::Components::Column.new(items: [fact_set], width:) }
 
     let(:fact_set) { MsTeamsHermes::Components::FactSet.new(facts: [fact]) }
     let(:fact) { { title: "foo", value: "bar" } }
@@ -28,7 +28,7 @@ RSpec.describe MsTeamsHermes::Components::Column do
             facts: [fact]
           }
         ],
-        width: width
+        width:
       }
 
       expect(component.to_hash).to eq hash

--- a/spec/msteams_hermes/components/container_spec.rb
+++ b/spec/msteams_hermes/components/container_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe MsTeamsHermes::Components::Container do
   describe "#to_hash" do
     subject(:component) do
       MsTeamsHermes::Components::Container.new(items: [fact_set],
-                                               style: style,
+                                               style:,
                                                select_action: action)
     end
 
@@ -36,7 +36,7 @@ RSpec.describe MsTeamsHermes::Components::Container do
             facts: [fact]
           }
         ],
-        style: style,
+        style:,
         selectAction: {
           type: "Action.OpenUrl",
           url: action_url,

--- a/spec/msteams_hermes/components/text_block_spec.rb
+++ b/spec/msteams_hermes/components/text_block_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe MsTeamsHermes::Components::TextBlock do
 
   describe "#to_hash" do
     subject(:component) do
-      MsTeamsHermes::Components::TextBlock.new(text: text,
-                                               color: color,
-                                               size: size,
-                                               font_type: font_type,
-                                               weight: weight,
-                                               wrap: wrap,
-                                               is_subtle: is_subtle)
+      MsTeamsHermes::Components::TextBlock.new(text:,
+                                               color:,
+                                               size:,
+                                               font_type:,
+                                               weight:,
+                                               wrap:,
+                                               is_subtle:)
     end
 
     let(:text) { "any text" }
@@ -34,13 +34,13 @@ RSpec.describe MsTeamsHermes::Components::TextBlock do
     it "renders the hash object" do
       hash = {
         type: "TextBlock",
-        text: text,
-        color: color,
-        size: size,
-        font_type: font_type,
-        weight: weight,
-        wrap: wrap,
-        is_subtle: is_subtle
+        text:,
+        color:,
+        size:,
+        font_type:,
+        weight:,
+        wrap:,
+        is_subtle:
       }
 
       expect(component.to_hash).to eq hash

--- a/spec/msteams_hermes/message_spec.rb
+++ b/spec/msteams_hermes/message_spec.rb
@@ -45,7 +45,6 @@ RSpec.describe MsTeamsHermes::Message do
       end
     end
 
-
     context "when network call is successful" do
       before do
         stub_request(:post, webhook_url).to_return(status: 200, body: "", headers: {})

--- a/spec/msteams_hermes/message_spec.rb
+++ b/spec/msteams_hermes/message_spec.rb
@@ -42,7 +42,9 @@ RSpec.describe MsTeamsHermes::Message do
     end
 
     context "when microsoft teams answer includes 413 error message" do
-      let(:webhook_response_body) { "some prefix #{MsTeamsHermes::Message::MSTEAMS_MESSAGE_413_ERROR_TOKEN} some suffix" }
+      let(:webhook_response_body) do
+        "some prefix #{MsTeamsHermes::Message::MSTEAMS_MESSAGE_413_ERROR_TOKEN} some suffix"
+      end
 
       it "raises an error if the body size is too big" do
         expect { subject }.to raise_error(MsTeamsHermes::Message::MessageBodyTooLargeError)
@@ -50,7 +52,7 @@ RSpec.describe MsTeamsHermes::Message do
     end
 
     context "when microsoft teams answer with an unexpected response body" do
-      let(:webhook_response_body) { 'something unexpected' }
+      let(:webhook_response_body) { "something unexpected" }
 
       it "raises an error if the body size is too big" do
         expect { subject }.to raise_error(MsTeamsHermes::Message::UnknownError)
@@ -58,7 +60,7 @@ RSpec.describe MsTeamsHermes::Message do
     end
 
     context "when network call is successful" do
-      let(:webhook_response_body) { '1' }
+      let(:webhook_response_body) { "1" }
 
       it "returns the network call response instance" do
         expect(subject).to be_a Net::HTTPOK

--- a/spec/msteams_hermes/message_spec.rb
+++ b/spec/msteams_hermes/message_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe MsTeamsHermes::Message do
   let(:fact_set) { MsTeamsHermes::Components::FactSet.new(facts: [fact]) }
   let(:card) { MsTeamsHermes::Components::AdaptiveCard.new(body: [fact_set]) }
 
-  let(:webhook_url) { "https://xingag.webhook.office.com/webhookb2/some-more-path-tokens" }
+  let(:webhook_url) { "https://some-company.webhook.office.com/webhookb2/some-more-path-tokens" }
 
   describe "#initialize" do
     it "throws an error if webhook_url is not provided" do

--- a/spec/msteams_hermes/message_spec.rb
+++ b/spec/msteams_hermes/message_spec.rb
@@ -6,6 +6,12 @@ require "msteams_hermes/components/fact_set"
 require "msteams_hermes/style"
 
 RSpec.describe MsTeamsHermes::Message do
+  let(:fact) { { title: "foo", value: "bar" } }
+  let(:fact_set) { MsTeamsHermes::Components::FactSet.new(facts: [fact]) }
+  let(:card) { MsTeamsHermes::Components::AdaptiveCard.new(body: [fact_set]) }
+
+  let(:webhook_url) { "https://xingag.webhook.office.com/webhookb2/some-more-path-tokens" }
+
   describe "#initialize" do
     it "throws an error if webhook_url is not provided" do
       expect do
@@ -28,12 +34,31 @@ RSpec.describe MsTeamsHermes::Message do
     end
   end
 
-  describe "#body_json" do
-    subject(:message) { MsTeamsHermes::Message.new(webhook_url: "webhook_url", content: card) }
+  describe "#deliver" do
+    subject { MsTeamsHermes::Message.new(webhook_url:, content: card).deliver }
 
-    let(:card) { MsTeamsHermes::Components::AdaptiveCard.new(body: [fact_set]) }
-    let(:fact_set) { MsTeamsHermes::Components::FactSet.new(facts: [fact]) }
-    let(:fact) { { title: "foo", value: "bar" } }
+    context "when the content is bigger than #{MsTeamsHermes::Message::MSTEAMS_MESSAGE_SIZE_LIMIT} bytes" do
+      let(:fact) { { title: "foo", value: "a" * MsTeamsHermes::Message::MSTEAMS_MESSAGE_SIZE_LIMIT } }
+
+      it "raises an error if the body size is too big" do
+        expect { subject }.to raise_error(MsTeamsHermes::Message::MessageBodyLikelyTooLargeError)
+      end
+    end
+
+
+    context "when network call is successful" do
+      before do
+        stub_request(:post, webhook_url).to_return(status: 200, body: "", headers: {})
+      end
+
+      it "returns the network call response instance" do
+        expect(subject).to be_a Net::HTTPOK
+      end
+    end
+  end
+
+  describe "#body_json" do
+    subject(:message) { MsTeamsHermes::Message.new(webhook_url:, content: card) }
 
     it "sends the POST request with the formatted body" do
       hash = {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+# debugger
+require "pry-byebug"
+
+# network stub
+require "webmock/rspec"
+
+# gem under test
 require "msteams_hermes"
 
 RSpec.configure do |config|


### PR DESCRIPTION
# Main PR outcome

It raise an error when the __currently known__ (it does not really peek/parse the response body to decide if an error happened) limit of the messages is reached

## Side refactorings

- adapt CI ruby versions
- Refactor `gemspec` / `Gemfile` file
- Adapt to ruby `3.1`+
- Add `webmock` gem and add tests for the `.deliver` method
- Add debugging gem for testing