### PR TITLE
Support msteams workflows

### DIFF
--- a/complex_example.rb
+++ b/complex_example.rb
@@ -19,7 +19,7 @@ header = MsTeamsHermes::Components::Container.new(
       weight: MsTeamsHermes::Style::FontWeight::BOLDER
     ),
     MsTeamsHermes::Components::TextBlock.new(
-      text: "#{Time.now.strftime("%A, %d %B %Y %H:%M:%S")}"
+      text: Time.now.strftime("%A, %d %B %Y %H:%M:%S").to_s
     )
   ]
 )

--- a/complex_example.rb
+++ b/complex_example.rb
@@ -19,7 +19,7 @@ header = MsTeamsHermes::Components::Container.new(
       weight: MsTeamsHermes::Style::FontWeight::BOLDER
     ),
     MsTeamsHermes::Components::TextBlock.new(
-      text: "Saturday, 1 January 2022"
+      text: "#{Time.now.strftime("%A, %d %B %Y %H:%M:%S")}"
     )
   ]
 )

--- a/lib/msteams_hermes/message.rb
+++ b/lib/msteams_hermes/message.rb
@@ -64,7 +64,7 @@ module MsTeamsHermes
 
         # For details see:
         # https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL%2Ctext1#send-messages-using-curl-and-powershell
-        if response.body != "1"
+        if not response.body.empty? and response.body != "1"
           raise MessageBodyTooLargeError, body_json.bytesize if response.body.include? MSTEAMS_MESSAGE_413_ERROR_TOKEN
 
           raise UnknownError, response.body

--- a/lib/msteams_hermes/message.rb
+++ b/lib/msteams_hermes/message.rb
@@ -103,13 +103,13 @@ module MsTeamsHermes
     private
 
     def response_from_mst_workflow_webhook?(response)
-      response.code == "202" and response.body.empty?
+      response.code == "202" && response.body.empty?
     end
 
     def response_from_mst_connector_webhook?(response)
       # For details see:
       # https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL%2Ctext1#send-messages-using-curl-and-powershell
-      response.code == "200" and response.body == "1"
+      response.code == "200" && response.body == "1"
     end
 
     def message_too_large?(response)

--- a/lib/msteams_hermes/message.rb
+++ b/lib/msteams_hermes/message.rb
@@ -3,6 +3,12 @@
 require "net/http"
 require "json"
 
+##
+# Module to encapsulate the logic that decides whether a given response
+# is of type workflow or connector type webhook.
+# Both types must be considered differently to support both types of
+# MSTeams webhooks.
+##
 module MsTeamsWebhookType
   def self.mst_workflow_webhook_response?(response)
     response.code == "202" and response.body.empty?
@@ -74,10 +80,11 @@ module MsTeamsHermes
 
         response = http.request(req)
 
-        return response if MsTeamsWebhookType::mst_workflow_webhook_response?(response)
-        return response if MsTeamsWebhookType::mst_connector_webhook_response?(response)
+        return response if MsTeamsWebhookType.mst_workflow_webhook_response?(response)
+        return response if MsTeamsWebhookType.mst_connector_webhook_response?(response)
 
         raise MessageBodyTooLargeError, body_json.bytesize if response.body.include? MSTEAMS_MESSAGE_413_ERROR_TOKEN
+
         raise UnknownError, response.body
       end
     end

--- a/lib/msteams_hermes/message.rb
+++ b/lib/msteams_hermes/message.rb
@@ -10,15 +10,6 @@ require "json"
 # MSTeams webhooks.
 ##
 module MsTeamsWebhookType
-  def self.mst_workflow_webhook_response?(response)
-    response.code == "202" and response.body.empty?
-  end
-
-  def self.mst_connector_webhook_response?(response)
-    # For details see:
-    # https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL%2Ctext1#send-messages-using-curl-and-powershell
-    response.code == "200" and response.body == "1"
-  end
 end
 
 module MsTeamsHermes
@@ -80,8 +71,8 @@ module MsTeamsHermes
 
         response = http.request(req)
 
-        return response if MsTeamsWebhookType.mst_workflow_webhook_response?(response)
-        return response if MsTeamsWebhookType.mst_connector_webhook_response?(response)
+        return response if mst_workflow_webhook_response?(response)
+        return response if mst_connector_webhook_response?(response)
 
         raise MessageBodyTooLargeError, body_json.bytesize if response.body.include? MSTEAMS_MESSAGE_413_ERROR_TOKEN
 
@@ -107,6 +98,17 @@ module MsTeamsHermes
           }
         ]
       }.to_json
+    end
+
+    private
+    def mst_workflow_webhook_response?(response)
+      response.code == "202" and response.body.empty?
+    end
+
+    def mst_connector_webhook_response?(response)
+      # For details see:
+      # https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL%2Ctext1#send-messages-using-curl-and-powershell
+      response.code == "200" and response.body == "1"
     end
   end
 end


### PR DESCRIPTION
Recently we got to know the world of Microsoft Teams workflows.
After playing around a bit, I found that this Gem still works successfully when wanting to post a message using Microsoft's adaptive card format.

However, some minor tweaks are required. 
With the introduction/replacement/migration of connector based webhooks to workflow based webhooks, both types of responses. This is because workflow based webhook responses have different properties, i.e. status code and body content.
In a previous implementation, we only had to consider the properties of a connector based webhook responses.
these can be found [here](https://github.com/xing/msteams_hermes/blob/00b56c0fa5b1ff4888f0867f7dcded7cd65ebd08/lib/msteams_hermes/message.rb#L67).

My current understanding is that each response type has the following properties:
1. Connector based webhooks
  - response code = 200
  - [response body = 1](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL%2Ctext1#send-messages-using-curl-and-powershell)
2. Workflow based webhooks 
  - response code = 202
  - response body = "" (empty string)
